### PR TITLE
fix: add and adjust various transaction typings

### DIFF
--- a/__tests__/resources/transactions.test.ts
+++ b/__tests__/resources/transactions.test.ts
@@ -11,7 +11,7 @@ describe("API - 2.0 - Resources - Transactions", () => {
 	});
 
 	it("should call \"create\" method", async () => {
-		const response = await resource.create([]);
+		const response = await resource.create({ transactions: [] });
 
 		expect(response.status).toBe(200);
 	});

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -36,10 +36,6 @@ export class Connection {
 	private async sendRequest<T>(method: string, url: string, opts?: Record<string, any>): Promise<IResponse<T>> {
 		opts = { ...this.opts, ...(opts || {}) };
 
-		if (opts.body && typeof opts !== "string") {
-			opts.body = JSON.stringify(opts.body);
-		}
-
 		// Do not retry unless explicitly stated.
 		if (!opts.retry) {
 			opts.retry = { retries: 0 };
@@ -50,7 +46,7 @@ export class Connection {
 		}
 
 		try {
-			const response = await ky(`${this.host}/${url}`, { ...opts, method });
+			const response = await ky(`${this.host}/${url}`, { ...opts, method, json: opts.body });
 
 			return {
 				body: await response.json(),

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -14,7 +14,8 @@ export class Connection {
 	}
 
 	public api<T extends AvailableResourcesName>(name: T) {
-		const selectedResourceClass = Resources[name];
+		// Convert to lower case to be backward-compatible
+		const selectedResourceClass = Resources[name.toLowerCase() as AvailableResourcesName];
 		return new selectedResourceClass(this) as AvailableResource<T>;
 	}
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,7 +4,7 @@ export interface IResponse<T> {
 	status: number;
 }
 
-export type DataResponse<T> = { data: T };
+export type DataResponse<T> = { data: T; errors: any };
 export interface PaginableResponse {
 	meta: {
 		count: number;

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -12,17 +12,17 @@ import { Wallets } from "./wallets";
 
 // tslint:disable-next-line: variable-name
 export const Resources = {
-	Blocks,
-	Bridgechains,
-	Businesses,
-	Delegates,
-	Locks,
-	Node,
-	Peers,
-	Rounds,
-	Transactions,
-	Votes,
-	Wallets,
+	blocks: Blocks,
+	bridgechains: Bridgechains,
+	businesses: Businesses,
+	delegates: Delegates,
+	locks: Locks,
+	node: Node,
+	peers: Peers,
+	rounds: Rounds,
+	transactions: Transactions,
+	votes: Votes,
+	wallets: Wallets,
 };
 
 export type AvailableResourcesName = keyof typeof Resources;

--- a/src/resources/transactions.ts
+++ b/src/resources/transactions.ts
@@ -31,7 +31,9 @@ export class Transactions extends Resource {
 	 *
 	 * @param payload The list of transactions to create.
 	 */
-	public async create(payload: object[]): Promise<ApiResponse<CreateTransactionApiResponse> & { errors?: any }> {
+	public async create(
+		payload: { transactions: object[] } & Record<string, any>,
+	): Promise<ApiResponse<CreateTransactionApiResponse> & { errors?: any }> {
 		return this.sendPost("transactions", payload);
 	}
 

--- a/src/resourcesTypes/transactions.ts
+++ b/src/resourcesTypes/transactions.ts
@@ -11,7 +11,7 @@ export interface Transaction {
 	sender: string;
 	senderPublicKey: string;
 	recipient: string;
-	asset?: Record<string, any>;
+	asset?: TransactionAssets;
 	signature: string;
 	signSignature?: string;
 	vendorField?: string;
@@ -23,6 +23,35 @@ export interface Transaction {
 	};
 	nonce: string;
 }
+
+export type TransactionAssets = {
+	ipfs?: string;
+	votes?: string[];
+	delegate?: {
+		username: string;
+	};
+	signature?: {
+		publicKey: string;
+	};
+	multiSignature?: {
+		publicKeys: string[];
+		min: string;
+	};
+	lock?: {
+		secretHash: string;
+		expiration: {
+			type: number;
+			value: number;
+		};
+	};
+	claim?: {
+		lockTransactionId: string;
+		unlockSecret: string;
+	};
+	refund?: {
+		lockTransactionId: string;
+	};
+} & Record<string, any>;
 
 export interface CreateTransactionApiResponse {
 	accept: string[];
@@ -94,11 +123,16 @@ export interface SearchTransactionsApiBody extends ApiBody {
 	blockId?: string;
 	type?: number;
 	version?: number;
+	network?: number;
 	senderPublicKey?: string;
 	senderId?: string;
 	recipientId?: string;
 	ownerId?: string;
 	vendorFieldHex?: string;
+	asset?: TransactionAssets;
+	signature?: string;
+	signatures?: string[];
+	MultiSignatureAddress?: string;
 	timestamp?: {
 		from?: number;
 		to?: number;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

 - Fix `ky` JSON body not applied correctly (`Content-type` header would not be set)
 - Fix transaction creation typings
 - Make available API names lowercase to be backward compatible and consistent with documentation (See https://sdk.ark.dev/typescript/complementary-examples#creating-and-broadcasting-a-transfer)
 - Add more transaction typings (search for assets)

## Checklist

<!-- Have you done all of these things?  -->

- [x] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

**Additional comments**
Searching for assets is possible but not documented (see https://api.ark.dev/public-rest-api/endpoints/transactions#body-parameters-1)

Search query example (IPFS):
```sh
curl -H "Content-Type: application/json" \
  -X POST \
  -d '{ "asset": { "ipfs": "QmT2yUde9NFsX6J7y97VGu8CeA5tLEshu5V7PVHeRqUcDA" } }' \
  https://api.ark.io/api/transactions/search \
  | jq
````